### PR TITLE
Updates Kubernetes APT GPG keys

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,7 +28,7 @@ EDGENET_PLAYBOOK="${EDGENET_PLAYBOOK:-edgenet-node.yml}"
 EDGENET_REF="${EDGENET_REF:-main}"
 
 # URL of the Git repository containing the playbook to run.
-EDGENET_REPOSITORY="${EDGENET_REPOSITORY:-https://github.com/EdgeNet-project/node.git}"
+EDGENET_REPOSITORY="${EDGENET_REPOSITORY:-https://github.com/mpiraux/edgenet-node.git}"
 
 # If the shell is non-interactive, do not ask for confirmation.
 # See https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -28,7 +28,7 @@ EDGENET_PLAYBOOK="${EDGENET_PLAYBOOK:-edgenet-node.yml}"
 EDGENET_REF="${EDGENET_REF:-main}"
 
 # URL of the Git repository containing the playbook to run.
-EDGENET_REPOSITORY="${EDGENET_REPOSITORY:-https://github.com/mpiraux/edgenet-node.git}"
+EDGENET_REPOSITORY="${EDGENET_REPOSITORY:-https://github.com/EdgeNet-project/node.git}"
 
 # If the shell is non-interactive, do not ask for confirmation.
 # See https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html.

--- a/roles/edgenet-kubernetes/defaults/main.yml
+++ b/roles/edgenet-kubernetes/defaults/main.yml
@@ -11,7 +11,7 @@ containerd_apt_repository: "deb [arch={{ containerd_apt_arch }}] https://downloa
 containerd_apt_gpg_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 
 kubernetes_apt_release_channel: main
-kubernetes_apt_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
+kubernetes_apt_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.asc] http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
 kubernetes_apt_gpg_key: https://packages.cloud.google.com/apt/doc/apt-key.gpg
 
 # RedHat

--- a/roles/edgenet-kubernetes/defaults/main.yml
+++ b/roles/edgenet-kubernetes/defaults/main.yml
@@ -11,7 +11,7 @@ containerd_apt_repository: "deb [arch={{ containerd_apt_arch }}] https://downloa
 containerd_apt_gpg_key: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
 
 kubernetes_apt_release_channel: main
-kubernetes_apt_repository: "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
+kubernetes_apt_repository: "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] http://apt.kubernetes.io/ kubernetes-xenial {{ kubernetes_apt_release_channel }}"
 kubernetes_apt_gpg_key: https://packages.cloud.google.com/apt/doc/apt-key.gpg
 
 # RedHat

--- a/roles/edgenet-kubernetes/tasks/kube-debian.yml
+++ b/roles/edgenet-kubernetes/tasks/kube-debian.yml
@@ -13,7 +13,7 @@
 - name: Ensure Kubernetes APT GPG key is present
   get_url:
     url: "{{ kubernetes_apt_gpg_key }}"
-    dest: /usr/share/keyrings/kubernetes-archive-keyring.gpg
+    dest: /etc/apt/keyrings/kubernetes-archive-keyring.gpg
 
 - name: Ensure Kubernetes APT repository is present
   apt_repository:

--- a/roles/edgenet-kubernetes/tasks/kube-debian.yml
+++ b/roles/edgenet-kubernetes/tasks/kube-debian.yml
@@ -13,7 +13,7 @@
 - name: Ensure Kubernetes APT GPG key is present
   get_url:
     url: "{{ kubernetes_apt_gpg_key }}"
-    dest: /etc/apt/keyrings/kubernetes-archive-keyring.gpg
+    dest: /etc/apt/keyrings/kubernetes-archive-keyring.asc
 
 - name: Ensure Kubernetes APT repository is present
   apt_repository:


### PR DESCRIPTION
Fixes #75.

I'm unsure this isn't breaking for older distributions; but it fixes Ubuntu 22.04.
Marking it first as a draft until I remove my repo URL change for testing.
